### PR TITLE
Make @types/jest a dev dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -923,17 +923,13 @@
       }
     },
     "@types/jest": {
-      "version": "24.0.13",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.13.tgz",
-      "integrity": "sha512-3m6RPnO35r7Dg+uMLj1+xfZaOgIHHHut61djNjzwExXN4/Pm9has9C6I1KMYSfz7mahDhWUOVg4HW/nZdv5Pww==",
+      "version": "24.9.1",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.9.1.tgz",
+      "integrity": "sha512-Fb38HkXSVA4L8fGKEZ6le5bB8r6MRWlOCZbVuWZcmOMSCd2wCYOwN1ibj8daIoV9naq7aaOZjrLCoCMptKU/4Q==",
+      "dev": true,
       "requires": {
-        "@types/jest-diff": "*"
+        "jest-diff": "^24.3.0"
       }
-    },
-    "@types/jest-diff": {
-      "version": "20.0.1",
-      "resolved": "https://registry.npmjs.org/@types/jest-diff/-/jest-diff-20.0.1.tgz",
-      "integrity": "sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA=="
     },
     "@types/mime-db": {
       "version": "1.27.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@hapi/hapi": "^18.3.1",
     "@types/bluebird": "^3.5.24",
     "@types/hapi__hapi": "^18.2.1",
-    "@types/jest": "^24.0.13",
     "@types/node": "^8.10.29",
     "@types/node-forge": "^0.8.2",
     "@types/prettier": "^1.16.3",
@@ -46,6 +45,7 @@
     "yargs": "^12.0.5"
   },
   "devDependencies": {
+    "@types/jest": "^24.0.13",
     "http-server": "^0.12.3",
     "jest": "^24.9.0",
     "lodash": "^4.17.15",


### PR DESCRIPTION
When package consumers have `@types/mocha` installed, [it can conflict](https://github.com/cypress-io/cypress/issues/6690) with intervene's `@types/jest` dependency. Making it a dev dependency prevents this.