### PR TITLE
Ensure package.json version gets updated on release

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -33,13 +33,13 @@ module.exports = {
         changelogFile: 'CHANGELOG.md',
       },
     ],
+    ['@semantic-release/npm'],
     [
       '@semantic-release/git',
       {
         assets: ['CHANGELOG.md'],
       },
     ],
-    ['@semantic-release/npm'],
     ['@semantic-release/github'],
   ],
 };


### PR DESCRIPTION
The version in package.json has been stuck on 3.0.1 for a while and is not in sync with the version in the npm registry. It doesn't really matter, but I thought I'd fix anyway.

It seems we need to swap the order of the semantic-release plugins, `npm` and `git`. See: https://github.com/semantic-release/semantic-release/issues/1593#issuecomment-656866839