### PR TITLE
Pin @types/bluebird to the last version that worked with TS v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2220,9 +2220,9 @@
       }
     },
     "@types/bluebird": {
-      "version": "3.5.34",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.34.tgz",
-      "integrity": "sha512-QMc57Pf067Rr78l6f4FftvuIXPYxu0VYFRKrZk1Clv+LWy7gN2fTBiAiv68askFHEHZcTLPFd01kNlpKOiSPgQ=="
+      "version": "3.5.36",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.36.tgz",
+      "integrity": "sha512-HBNx4lhkxN7bx6P0++W8E289foSu8kO8GCk2unhuVggO+cE7rh9DhZUyPhUxNRG9m+5B5BTKxZQ5ZP92x/mx9Q=="
     },
     "@types/graceful-fs": {
       "version": "4.1.5",
@@ -13429,9 +13429,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.9",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
-      "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w=="
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q=="
     },
     "uglify-js": {
       "version": "3.13.6",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "dependencies": {
     "@hapi/hapi": "^20.1.3",
-    "@types/bluebird": "^3.5.24",
+    "@types/bluebird": "3.5.36",
     "@types/hapi__hapi": "^20.0.8",
     "@types/node": "*",
     "@types/node-forge": "^0.8.2",
@@ -41,7 +41,7 @@
     "sudo-prompt": "^8.2.3",
     "susie": "^3.0.0",
     "ts-node": "^8.10.1",
-    "typescript": "^3.8.3",
+    "typescript": "^3.9.10",
     "why-is-node-running": "^2.0.3",
     "yargs": "^12.0.5"
   },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "sudo-prompt": "^8.2.3",
     "susie": "^3.0.0",
     "ts-node": "^8.10.1",
-    "typescript": "^3.9.10",
+    "typescript": "~3.9.10",
     "why-is-node-running": "^2.0.3",
     "yargs": "^12.0.5"
   },


### PR DESCRIPTION
## Scope

Intervene currently supports `3.5.x` versions of `@types/bluebird`. The latest `3.5.x` versions drop support for TS v3 in favor of TS v4: https://www.npmjs.com/package/@types/bluebird?activeTab=versions

Since Intervene uses TS v3, we need to pin the version of `@types/bluebird` to one that is compatible. Otherwise you will see a lot of TS errors when running a fresh install of Intervene.

Pinning is a band-aid fix; obviously in the long term we should upgrade Intervene to TS v4.

## How to test

1. Checkout master branch of this repo locally.
2. Change the version of `@types/bluebird` to `3.5.38` (without `^`) in package.json.
3. Run `make build`. It should fail with lots of TS errors.
3. Undo the change and checkout this branch.
4. Run `make build` again. It should succeed with no errors.