### PR TITLE
use default GITHUB_TOKEN over CI_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,5 +31,5 @@ jobs:
         run: make build
       - name: Release
         env:
-          GH_TOKEN: ${{ secrets.CI_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run semantic-release


### PR DESCRIPTION
We [got paged](https://soundcloud.slack.com/archives/C03LPG52N/p1775239687634359) that we needed to roll `CI_TOKEN`.
I deleted it on @pablofmena 's recommendation.
Rather than recreating it, here, I reference the repo's default `GITHUB_TOKEN`