### PR TITLE
fix(ci): work around broken npm in Node 22.22.2

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,6 +23,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm install -g npm@11
+      - name: Upgrade npm
+        run: |
+          npm_major=$(npm --version | cut -d. -f1)
+          if [ "$npm_major" -lt 11 ]; then
+            npm install -g npm@10 && npm install -g npm@11
+          fi
       - run: npm ci
       - run: make test


### PR DESCRIPTION
## Summary

- Node.js 22.22.2 bundles npm 10.9.7 which has a broken `promise-retry` dependency, causing `npm install -g npm@11` to fail with `MODULE_NOT_FOUND` ([nodejs/node#62425](https://github.com/nodejs/node/issues/62425), [actions/runner-images#13883](https://github.com/actions/runner-images/issues/13883))
- Replace the single `npm install -g npm@11` with a two-step upgrade: first to npm@10 (10.9.8 replaced `promise-retry` with `@gar/promise-retry`), then to npm@11
- Skip the upgrade entirely when bundled npm is already >= 11 (Node 24)

## Test plan

- [x] All 6 matrix entries pass (Node 20/22/24 on ubuntu + macOS)

Made with [Cursor](https://cursor.com)