### PR TITLE
fix(ci): add issues:write permission for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   id-token: write
   contents: write
+  issues: write
 
 jobs:
   release:


### PR DESCRIPTION
## Scope

Follow-up to #89 (switch from `CI_TOKEN` PAT to `GITHUB_TOKEN`). The release workflow was failing because:

1. **`@semantic-release/github`** needs `issues: write` to create failure-reporting issues — the workflow only granted `contents: write` and `id-token: write`.
2. **Branch protection** on `master` restricted pushes to `intervene-ci` user and two teams — `github-actions[bot]` was not allowed. This was fixed separately by adding the GitHub Actions app to the push restrictions via the API.

## Implementation

Adds `issues: write` to the workflow-level `permissions` block in `release.yml`.

The branch protection change (adding `github-actions` to the allowed push actors) was applied directly via the GitHub API and is already in effect.

## How To Test

Merge this PR and wait for the next releasable commit to land on `master`. The release workflow should complete without the `403 Resource not accessible by integration` error or the `EGITNOPERMISSION` push failure.

Made with [Cursor](https://cursor.com)