### PR TITLE
fix(ci): remove persist-credentials:false for GITHUB_TOKEN auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          persist-credentials: false
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Scope

Follow-up to #96 (switch to `GITHUB_TOKEN`). The release workflow still fails because `persist-credentials: false` on `actions/checkout` prevents the checkout action from setting up git credentials. Semantic-release then tries to authenticate git push by embedding the token in the HTTPS URL, but GitHub rejects it with:

```
remote: Invalid username or token.
Password authentication is not supported for Git operations.
```

See [failed run](https://github.com/soundcloud/intervene/actions/runs/24025321786/job/70062441988).

## Implementation

Removes `persist-credentials: false` from the checkout step. This setting was needed when using `CI_TOKEN` (a PAT from `intervene-ci`) to prevent the checkout action's `GITHUB_TOKEN` credentials from conflicting with the PAT. Now that we use `GITHUB_TOKEN` for everything, checkout can handle git auth natively via its `extraheader` config.

## How To Test

Merge and wait for the next releasable commit on `master`. The release workflow should push the version tag and CHANGELOG commit without auth errors.

Made with [Cursor](https://cursor.com)