### PR TITLE
fix(ci): use intervene-ci PAT for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,6 @@ on:
 
 permissions:
   id-token: write
-  contents: write
-  issues: write
 
 jobs:
   release:
@@ -17,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -30,5 +30,5 @@ jobs:
         run: make build
       - name: Release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.CI_TOKEN }}
         run: npm run semantic-release


### PR DESCRIPTION
## Scope

Follow-up to #96 and #98. The `GITHUB_TOKEN` cannot push to protected branches — this is a GitHub platform limitation regardless of push restriction settings. Switches back to `CI_TOKEN` (a fine-grained PAT from `intervene-ci`, which is in the `master` push restrictions) for semantic-release operations.

## Implementation

- **`GH_TOKEN`** set to `CI_TOKEN` secret — used by semantic-release for both GitHub API calls (`@semantic-release/github`) and git push (`@semantic-release/git`).
- **`persist-credentials: false`** restored on checkout — prevents `actions/checkout` from injecting `GITHUB_TOKEN` git credentials that would conflict with the PAT.
- **`id-token: write`** kept for npm OIDC provenance publishing.
- **`contents: write` and `issues: write` removed** from workflow permissions — no longer needed since the PAT provides those scopes.
- **`CI_TOKEN` secret** is a fine-grained PAT from `intervene-ci` scoped to `soundcloud/intervene` with `contents:write` + `issues:write`.

## How To Test

Merge and wait for the next releasable commit on `master`. The release workflow should complete the full cycle: analyze commits, update CHANGELOG, bump version, push to master, publish to npm, and create a GitHub Release.

Made with [Cursor](https://cursor.com)