### PR TITLE
fix(ci): wire sc-governed-write-auth for security gate bypass

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       # See https://eng-doc.soundcloud.org/security/security-gate/bypass-allowlist/
       - name: Authenticate for governed default-branch push
         id: sc-governed-write
-        uses: soundcloud/security-tooling/.github/actions/sc-governed-write-auth@2e4086b2fe93e68d074a8037d18f55a3f0ea78ce
+        uses: soundcloud/security-tooling/.github/actions/sc-governed-write-auth@main
         with:
           sc-governed-write-app-private-key: ${{ secrets.SC_GOVERNED_WRITE_APP_PRIVATE_KEY }}
       - name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,9 @@ jobs:
         run: npm ci
       - name: Build
         run: make build
-      # Authenticate as sc-governed-write so the push bypasses the security gate.
+      # Configure git credentials as sc-governed-write so @semantic-release/git's
+      # push to master bypasses the security gate. Keep CI_TOKEN as GH_TOKEN for
+      # @semantic-release/github (releases, issue comments, failure issues).
       # See https://eng-doc.soundcloud.org/security/security-gate/bypass-allowlist/
       - name: Authenticate for governed default-branch push
         id: sc-governed-write
@@ -39,5 +41,5 @@ jobs:
           sc-governed-write-app-private-key: ${{ secrets.SC_GOVERNED_WRITE_APP_PRIVATE_KEY }}
       - name: Release
         env:
-          GH_TOKEN: ${{ steps.sc-governed-write.outputs.token }}
+          GH_TOKEN: ${{ secrets.CI_TOKEN }}
         run: npm run semantic-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:
 
 permissions:
   id-token: write
+  contents: write
+  packages: read
 
 jobs:
   release:
@@ -28,7 +30,14 @@ jobs:
         run: npm ci
       - name: Build
         run: make build
+      # Authenticate as sc-governed-write so the push bypasses the security gate.
+      # See https://eng-doc.soundcloud.org/security/security-gate/bypass-allowlist/
+      - name: Authenticate for governed default-branch push
+        id: sc-governed-write
+        uses: soundcloud/security-tooling/.github/actions/sc-governed-write-auth@08ef0c295fb3692643771a8100a1e6649c50ac9a
+        with:
+          sc-governed-write-app-private-key: ${{ secrets.SC_GOVERNED_WRITE_APP_PRIVATE_KEY }}
       - name: Release
         env:
-          GH_TOKEN: ${{ secrets.CI_TOKEN }}
+          GH_TOKEN: ${{ steps.sc-governed-write.outputs.token }}
         run: npm run semantic-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       # See https://eng-doc.soundcloud.org/security/security-gate/bypass-allowlist/
       - name: Authenticate for governed default-branch push
         id: sc-governed-write
-        uses: soundcloud/security-tooling/.github/actions/sc-governed-write-auth@08ef0c295fb3692643771a8100a1e6649c50ac9a
+        uses: soundcloud/security-tooling/.github/actions/sc-governed-write-auth@2e4086b2fe93e68d074a8037d18f55a3f0ea78ce
         with:
           sc-governed-write-app-private-key: ${{ secrets.SC_GOVERNED_WRITE_APP_PRIVATE_KEY }}
       - name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+          fetch-depth: 0
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -30,16 +31,24 @@ jobs:
         run: npm ci
       - name: Build
         run: make build
-      # Configure git credentials as sc-governed-write so @semantic-release/git's
-      # push to master bypasses the security gate. Keep CI_TOKEN as GH_TOKEN for
-      # @semantic-release/github (releases, issue comments, failure issues).
-      # See https://eng-doc.soundcloud.org/security/security-gate/bypass-allowlist/
+      - name: Prepare release (analyze, changelog, npm publish)
+        env:
+          SEMANTIC_RELEASE_PHASE: prep
+          GH_TOKEN: ${{ secrets.CI_TOKEN }}
+        run: npm run semantic-release
+      # Mint sc-governed-write only for the default-branch push; prep and GitHub release
+      # keep CI_TOKEN (npm OIDC provenance and @semantic-release/github parity).
+      # https://eng-doc.soundcloud.org/security/security-gate/bypass-allowlist/
       - name: Authenticate for governed default-branch push
         id: sc-governed-write
         uses: soundcloud/security-tooling/.github/actions/sc-governed-write-auth@main
         with:
           sc-governed-write-app-private-key: ${{ secrets.SC_GOVERNED_WRITE_APP_PRIVATE_KEY }}
-      - name: Release
+      - name: Push release commit and tags to default branch
+        id: release-push
+        run: ./scripts/release-push.sh
+      - name: Create GitHub release
+        if: steps.release-push.outputs.released == 'true'
         env:
           GH_TOKEN: ${{ secrets.CI_TOKEN }}
-        run: npm run semantic-release
+        run: ./scripts/release-github.sh

--- a/release.config.js
+++ b/release.config.js
@@ -1,35 +1,52 @@
 const noteKeywords = ['BREAKING CHANGE', 'BREAKING CHANGES', 'BREAKING'];
 
-module.exports = {
-  plugins: [
-    [
-      '@semantic-release/commit-analyzer',
-      {
-        preset: 'angular',
-        releaseRules: [
-          { type: 'refactor', release: 'patch' },
-          { type: 'revert', release: 'patch' },
-        ],
-        parserOpts: {
-          noteKeywords,
-        },
-      },
+const commitAnalyzer = [
+  '@semantic-release/commit-analyzer',
+  {
+    preset: 'angular',
+    releaseRules: [
+      { type: 'refactor', release: 'patch' },
+      { type: 'revert', release: 'patch' },
     ],
-    [
-      '@semantic-release/release-notes-generator',
-      {
-        preset: 'angular',
-        parserOpts: {
-          noteKeywords,
-        },
-        writerOpts: {
-          commitsSort: ['subject', 'scope'],
-        },
-      },
-    ],
+    parserOpts: {
+      noteKeywords,
+    },
+  },
+];
+
+const releaseNotesGenerator = [
+  '@semantic-release/release-notes-generator',
+  {
+    preset: 'angular',
+    parserOpts: {
+      noteKeywords,
+    },
+    writerOpts: {
+      commitsSort: ['subject', 'scope'],
+    },
+  },
+];
+
+const pluginsByPhase = {
+  prep: [
+    commitAnalyzer,
+    releaseNotesGenerator,
+    ['@semantic-release/changelog'],
+    ['@semantic-release/npm'],
+  ],
+  all: [
+    commitAnalyzer,
+    releaseNotesGenerator,
     ['@semantic-release/changelog'],
     ['@semantic-release/npm'],
     ['@semantic-release/git'],
     ['@semantic-release/github'],
   ],
+};
+
+const phase = process.env.SEMANTIC_RELEASE_PHASE || 'all';
+const plugins = pluginsByPhase[phase] || pluginsByPhase.all;
+
+module.exports = {
+  plugins,
 };

--- a/scripts/release-github.sh
+++ b/scripts/release-github.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION=$(node -p "require('./package.json').version")
+TAG="v${VERSION}"
+
+if gh release view "$TAG" >/dev/null 2>&1; then
+  echo "GitHub release ${TAG} already exists."
+  exit 0
+fi
+
+NOTES=$(awk -v version="$VERSION" '
+  $0 ~ "^## \\[" version "\\]" { capture=1; next }
+  capture && /^# / { exit }
+  capture { print }
+' CHANGELOG.md)
+
+gh release create "$TAG" --notes "$NOTES"

--- a/scripts/release-push.sh
+++ b/scripts/release-push.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+assets=(CHANGELOG.md package.json package-lock.json)
+existing=()
+for file in "${assets[@]}"; do
+  if [ -e "$file" ]; then
+    existing+=("$file")
+  fi
+done
+
+if [ ${#existing[@]} -eq 0 ]; then
+  echo "No release assets found."
+  echo "released=false" >> "${GITHUB_OUTPUT:-/dev/null}"
+  exit 0
+fi
+
+if git diff --quiet HEAD -- "${existing[@]}" 2>/dev/null && \
+   [ -z "$(git status --porcelain -- "${existing[@]}")" ]; then
+  echo "No release changes to push."
+  echo "released=false" >> "${GITHUB_OUTPUT:-/dev/null}"
+  exit 0
+fi
+
+VERSION=$(node -p "require('./package.json').version")
+TAG="v${VERSION}"
+MESSAGE="chore(release): ${VERSION}"
+
+git add "${existing[@]}"
+git commit -m "${MESSAGE}"
+git tag -a "${TAG}" -m "${MESSAGE}"
+git push origin HEAD --tags
+
+echo "released=true" >> "${GITHUB_OUTPUT:-/dev/null}"
+echo "version=${VERSION}" >> "${GITHUB_OUTPUT:-/dev/null}"


### PR DESCRIPTION
## Context

The release workflow runs `semantic-release` after CI passes. `@semantic-release/git` pushes version-bump commits directly to `master`; once the org security gate is enabled, that push must authenticate as `sc-governed-write[bot]`.

## Problem

The initial wiring replaced `CI_TOKEN` entirely with the governed-write token. `sc-governed-write` only has `contents: write`, but `@semantic-release/github` also needs `issues: write` for failure reporting and issue/PR comments.

## Solution

Use both tokens with separate roles (eng-doc Pattern B):

- **`sc-governed-write-auth`** configures git credentials immediately before release, so `@semantic-release/git`'s push to `master` bypasses the security gate.
- **`CI_TOKEN`** stays as `GH_TOKEN` for `@semantic-release/github` (GitHub Releases, issue comments, failure issues).

Adds `contents: write` and `packages: read` permissions required by the composite action.

## Related PRs

- [soundcloud/security-tooling PR](https://github.com/soundcloud/security-tooling/pull/86) to enroll `intervene` in the security gate rollout and allowlist this workflow (must merge second, after ProdSec review).

## ProdSec setup (after security-tooling PR merges)

1. Install `sc-governed-write` GitHub App on this repo.
2. Grant this repo access to the `SC_GOVERNED_WRITE_APP_PRIVATE_KEY` org secret.

## Follow-ups

- Add `sc-governed-write` to the repo branch protection / ruleset bypass list (see PR comments).
- Consider migrating legacy branch protection to a repo ruleset per eng-doc.