### PR TITLE
fix(ci): route release commits through auto-PR automerge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,20 +3,35 @@ on:
   workflow_run:
     workflows: ['Node.js CI']
     types: [completed]
+    branches: [master]
+
+# Serialize release runs so a CI re-trigger waits for tag push to finish.
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 permissions:
   id-token: write
+  contents: write
+  packages: read
+  pull-requests: write
 
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Merging the release PR re-triggers Node.js CI; skip that run to avoid
+    # a release loop while the commit/tag are briefly out of sync.
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      (github.event.workflow_run.head_commit == null ||
+       !startsWith(github.event.workflow_run.head_commit.message, 'chore(release):'))
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+          fetch-depth: 0
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -28,7 +43,50 @@ jobs:
         run: npm ci
       - name: Build
         run: make build
-      - name: Release
+      - name: Prepare release (analyze, changelog, npm publish)
         env:
+          SEMANTIC_RELEASE_PHASE: prep
           GH_TOKEN: ${{ secrets.CI_TOKEN }}
         run: npm run semantic-release
+      - name: Read release version
+        id: version
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+      - name: Open release PR
+        id: cpr
+        uses: sc-actions-forks/create-pull-request@6699836a213cf8b28c4f0408a404a6ac79d4458a
+        with:
+          branch: automation/release-${{ steps.version.outputs.version }}
+          base: master
+          title: 'chore(release): ${{ steps.version.outputs.version }}'
+          commit-message: 'chore(release): ${{ steps.version.outputs.version }}'
+          delete-branch: true
+      - name: Enable auto-merge for release PR
+        if: steps.cpr.outputs.pull-request-number != ''
+        run: |
+          PR="${{ steps.cpr.outputs.pull-request-number }}"
+          gh pr merge --auto --squash "$PR" || gh pr merge --squash "$PR"
+        env:
+          GH_TOKEN: ${{ secrets.SC_GITHUB_BOT_PAT }}
+      - name: Wait for release PR to merge
+        if: steps.cpr.outputs.pull-request-number != ''
+        run: |
+          PR="${{ steps.cpr.outputs.pull-request-number }}"
+          while [ "$(gh pr view "$PR" --json state --jq '.state')" = "OPEN" ]; do
+            sleep 10
+          done
+          if [ "$(gh pr view "$PR" --json state --jq '.state')" != "MERGED" ]; then
+            echo "Release PR was not merged (state: $(gh pr view "$PR" --json state --jq '.state'))"
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.SC_GITHUB_BOT_PAT }}
+      - name: Tag release and push
+        if: steps.cpr.outputs.pull-request-number != ''
+        run: ./scripts/release-tag.sh
+        env:
+          GH_TOKEN: ${{ secrets.SC_GITHUB_BOT_PAT }}
+      - name: Create GitHub release
+        if: steps.cpr.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ secrets.CI_TOKEN }}
+        run: ./scripts/release-github.sh

--- a/release.config.js
+++ b/release.config.js
@@ -1,35 +1,52 @@
 const noteKeywords = ['BREAKING CHANGE', 'BREAKING CHANGES', 'BREAKING'];
 
-module.exports = {
-  plugins: [
-    [
-      '@semantic-release/commit-analyzer',
-      {
-        preset: 'angular',
-        releaseRules: [
-          { type: 'refactor', release: 'patch' },
-          { type: 'revert', release: 'patch' },
-        ],
-        parserOpts: {
-          noteKeywords,
-        },
-      },
+const commitAnalyzer = [
+  '@semantic-release/commit-analyzer',
+  {
+    preset: 'angular',
+    releaseRules: [
+      { type: 'refactor', release: 'patch' },
+      { type: 'revert', release: 'patch' },
     ],
-    [
-      '@semantic-release/release-notes-generator',
-      {
-        preset: 'angular',
-        parserOpts: {
-          noteKeywords,
-        },
-        writerOpts: {
-          commitsSort: ['subject', 'scope'],
-        },
-      },
-    ],
+    parserOpts: {
+      noteKeywords,
+    },
+  },
+];
+
+const releaseNotesGenerator = [
+  '@semantic-release/release-notes-generator',
+  {
+    preset: 'angular',
+    parserOpts: {
+      noteKeywords,
+    },
+    writerOpts: {
+      commitsSort: ['subject', 'scope'],
+    },
+  },
+];
+
+const pluginsByPhase = {
+  prep: [
+    commitAnalyzer,
+    releaseNotesGenerator,
+    ['@semantic-release/changelog'],
+    ['@semantic-release/npm'],
+  ],
+  all: [
+    commitAnalyzer,
+    releaseNotesGenerator,
     ['@semantic-release/changelog'],
     ['@semantic-release/npm'],
     ['@semantic-release/git'],
     ['@semantic-release/github'],
   ],
+};
+
+const phase = process.env.SEMANTIC_RELEASE_PHASE || 'all';
+const plugins = pluginsByPhase[phase] || pluginsByPhase.all;
+
+module.exports = {
+  plugins,
 };

--- a/scripts/release-github.sh
+++ b/scripts/release-github.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION=$(node -p "require('./package.json').version")
+TAG="v${VERSION}"
+
+if gh release view "$TAG" >/dev/null 2>&1; then
+  echo "GitHub release ${TAG} already exists."
+  exit 0
+fi
+
+NOTES=$(awk -v version="$VERSION" '
+  $0 ~ "^## \\[" version "\\]" { capture=1; next }
+  capture && /^# / { exit }
+  capture { print }
+' CHANGELOG.md)
+
+gh release create "$TAG" --notes "$NOTES"

--- a/scripts/release-github.sh
+++ b/scripts/release-github.sh
@@ -10,8 +10,8 @@ if gh release view "$TAG" >/dev/null 2>&1; then
 fi
 
 NOTES=$(awk -v version="$VERSION" '
-  $0 ~ "^## \\[" version "\\]" { capture=1; next }
-  capture && /^# / { exit }
+  index($0, "## [" version "]") == 1 || index($0, "# [" version "]") == 1 { capture=1; next }
+  capture && /^##? / { exit }
   capture { print }
 ' CHANGELOG.md)
 

--- a/scripts/release-tag.sh
+++ b/scripts/release-tag.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git fetch origin master
+git checkout master
+git pull origin master
+
+VERSION=$(node -p "require('./package.json').version")
+TAG="v${VERSION}"
+MESSAGE="chore(release): ${VERSION}"
+
+if git rev-parse "$TAG" >/dev/null 2>&1; then
+  echo "Tag ${TAG} already exists."
+  exit 0
+fi
+
+git tag -a "${TAG}" -m "${MESSAGE}"
+git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${TAG}"


### PR DESCRIPTION
## Context

The release workflow runs `semantic-release` after Node.js CI passes on `master`. Once the org security gate is enabled, default-branch writes must go through a PR rather than a direct push.

## Problem

The workflow currently lets `@semantic-release/git` push version-bump commits directly to `master`. That will be blocked by the security gate. A naive auto-PR replacement re-triggers Node.js CI when the release PR merges, which can loop or double-release while the git tag lags the merged commit.

## Solution

Split `semantic-release` into a prep phase (analyze, changelog, npm publish) and post-merge steps (tag + GitHub release). Version bumps open an auto-merge PR via `sc-actions-forks/create-pull-request`, merged with `SC_GITHUB_BOT_PAT` (required because `master` has push restrictions). Two guards prevent the anticipated loop from [security-tooling#101](https://github.com/soundcloud/security-tooling/pull/101): skip runs whose triggering CI commit starts with `chore(release):`, and a `concurrency` group so a re-triggered run waits for the in-flight release (including tag push) to finish.

Made with [Cursor](https://cursor.com)