### PR TITLE
fix(ci): use SC_BOT_GITHUB_TOKEN for release automerge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         id: cpr
         uses: sc-actions-forks/create-pull-request@6699836a213cf8b28c4f0408a404a6ac79d4458a
         with:
-          token: ${{ secrets.SC_GITHUB_BOT_PAT }}
+          token: ${{ secrets.SC_BOT_GITHUB_TOKEN }}
           branch: automation/release-${{ steps.version.outputs.version }}
           base: master
           title: 'chore(release): ${{ steps.version.outputs.version }}'
@@ -68,7 +68,7 @@ jobs:
           gh pr review --approve "$PR" || true
           gh pr merge --auto --squash "$PR" || gh pr merge --squash "$PR"
         env:
-          GH_TOKEN: ${{ secrets.SC_GITHUB_BOT_PAT }}
+          GH_TOKEN: ${{ secrets.SC_BOT_GITHUB_TOKEN }}
       - name: Wait for release PR to merge
         if: steps.cpr.outputs.pull-request-number != ''
         run: |
@@ -81,12 +81,12 @@ jobs:
             exit 1
           fi
         env:
-          GH_TOKEN: ${{ secrets.SC_GITHUB_BOT_PAT }}
+          GH_TOKEN: ${{ secrets.SC_BOT_GITHUB_TOKEN }}
       - name: Tag release and push
         if: steps.cpr.outputs.pull-request-number != ''
         run: ./scripts/release-tag.sh
         env:
-          GH_TOKEN: ${{ secrets.SC_GITHUB_BOT_PAT }}
+          GH_TOKEN: ${{ secrets.SC_BOT_GITHUB_TOKEN }}
       - name: Create GitHub release
         if: steps.cpr.outputs.pull-request-number != ''
         env:


### PR DESCRIPTION
## Context

The Release workflow opens auto-PRs for version bumps after security-gate enrollment (#109, #111). Automerge and tag-push steps need a `sc-github-bot` PAT.

## Problem

#111 merged with `SC_GITHUB_BOT_PAT`, but that org secret is not granted to `intervene`. The Release run after #109 failed with an empty `GH_TOKEN`, and release PR #110 was closed without merging — `master` is still at 5.0.2 while npm already has 5.0.3.

## Solution

Switch all four `SC_GITHUB_BOT_PAT` references in `release.yml` to `SC_BOT_GITHUB_TOKEN`, which `intervene` already has (same pattern as `k8s-workloads`, `terraform-deploys`).

## Follow-ups

After merge, re-run the Release workflow to open and automerge the 5.0.3 version-bump PR and create the GitHub release.


Made with [Cursor](https://cursor.com)